### PR TITLE
fix: force-push and unprotect GitLab main before mirror push

### DIFF
--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -21,10 +21,21 @@ jobs:
           CODEBERG_TOKEN: ${{ secrets.CODEBERG_TOKEN }}
           GITEA_SSH_KEY: ${{ secrets.GITEA_SSH_KEY }}
         run: |
-          git push "https://zaccesss:${GITLAB_TOKEN}@gitlab.com/zaccesss/${{ github.event.repository.name }}.git" HEAD:main
-          git push "https://zaccesss:${CODEBERG_TOKEN}@codeberg.org/zaccesss/${{ github.event.repository.name }}.git" HEAD:main
+          REPO="${{ github.event.repository.name }}"
+          # GitLab: unprotect main, force-push, reprotect
+          GL_PROJECT_ID=$(curl -s -H "PRIVATE-TOKEN: ${GITLAB_TOKEN}" \
+            "https://gitlab.com/api/v4/projects/zaccesss%2F${REPO}" | jq -r '.id')
+          curl -s -X DELETE -H "PRIVATE-TOKEN: ${GITLAB_TOKEN}" \
+            "https://gitlab.com/api/v4/projects/${GL_PROJECT_ID}/protected_branches/main" > /dev/null
+          git push --force "https://zaccesss:${GITLAB_TOKEN}@gitlab.com/zaccesss/${REPO}.git" HEAD:main
+          curl -s -X POST -H "PRIVATE-TOKEN: ${GITLAB_TOKEN}" \
+            "https://gitlab.com/api/v4/projects/${GL_PROJECT_ID}/protected_branches" \
+            -d "name=main&push_access_level=40&merge_access_level=40" > /dev/null
+          # Codeberg: force-push (no branch protection issues)
+          git push --force "https://zaccesss:${CODEBERG_TOKEN}@codeberg.org/zaccesss/${REPO}.git" HEAD:main
+          # Gitea: force-push via SSH
           echo "$GITEA_SSH_KEY" > /tmp/gitea_key
           chmod 600 /tmp/gitea_key
           mkdir -p ~/.ssh && ssh-keyscan -H gitea.com >> ~/.ssh/known_hosts 2>/dev/null
-          GIT_SSH_COMMAND="ssh -i /tmp/gitea_key" git push git@gitea.com:zaccesss/${{ github.event.repository.name }}.git HEAD:main
+          GIT_SSH_COMMAND="ssh -i /tmp/gitea_key" git push --force git@gitea.com:zaccesss/${REPO}.git HEAD:main
           rm /tmp/gitea_key


### PR DESCRIPTION
Mirror pushes were not using `--force`, and GitLab's branch protection blocks force-pushes without first removing it via the API. This applies the same fix used in dotfiles#20: unprotect GitLab main, force-push, reprotect. Also adds `--force` to Codeberg and Gitea pushes to handle any future squash-merge divergence.